### PR TITLE
Use doTransfer for revokeTokenGrant

### DIFF
--- a/contracts/MiniMeVestedToken.sol
+++ b/contracts/MiniMeVestedToken.sol
@@ -163,10 +163,7 @@ contract MiniMeVestedToken is MiniMeToken {
     grants[_holder][_grantId] = grants[_holder][grants[_holder].length.sub(1)];
     grants[_holder].length -= 1;
 
-    updateValueAtNow(balances[receiver], balanceOf(receiver) + nonVested);
-    updateValueAtNow(balances[_holder], balanceOf(_holder) - nonVested);
-
-    Transfer(_holder, receiver, nonVested);
+    doTransfer(_holder, receiver, nonVested);
   }
 
   /**

--- a/test/BloomTokenSale.ts
+++ b/test/BloomTokenSale.ts
@@ -531,7 +531,11 @@ contract("BloomTokenSale", function([_, investor, wallet, purchaser]) {
       latestTime + 80
     );
 
-    await timer(70);
+    await timer(100);
+    await sale.finalize();
+
+    // Remove the controller so that we can work around the onTransfer check
+    await sale.changeTokenController("0x0");
     await sale.revokeGrant(investor, 0);
 
     (await token.tokenGrantsCount(investor)).should.be.bignumber.equal(0);


### PR DESCRIPTION
This lets us reuse the existing transfer functionality which MiniMe
provides. I use `doTransfer` and not `transferFrom` to go around the
vesting functionality. The only downside here is that we could only
revoke grants after the sale is over once we have a different controller
in place. This is fine though since the cliffs of all of the tokens we
are granting should be at least two months after a controller that
supports transfers is released.

Fixes #66