### PR TITLE
Add finishPresale and set price there

### DIFF
--- a/contracts.d.ts
+++ b/contracts.d.ts
@@ -45,6 +45,7 @@ export interface BloomTokenSaleInstance extends ContractInstance {
     options?: TransactionOptions
   ): Promise<void>,
   cap(options?: TransactionOptions): Promise<BigNumber.BigNumber>,
+  finishPresale(cents: UInt, options?: TransactionOptions): Promise<boolean>,
   unpause(options?: TransactionOptions): Promise<void>,
   weiRaised(options?: TransactionOptions): Promise<BigNumber.BigNumber>,
   onTransfer(
@@ -58,10 +59,6 @@ export interface BloomTokenSaleInstance extends ContractInstance {
   paused(options?: TransactionOptions): Promise<boolean>,
   finishConfiguration(options?: TransactionOptions): Promise<boolean>,
   startTime(options?: TransactionOptions): Promise<BigNumber.BigNumber>,
-  setEtherPriceInCents(
-    cents: UInt,
-    options?: TransactionOptions
-  ): Promise<void>,
   pause(options?: TransactionOptions): Promise<void>,
   configured(options?: TransactionOptions): Promise<boolean>,
   isFinalized(options?: TransactionOptions): Promise<boolean>,

--- a/test/PlaceholderController.ts
+++ b/test/PlaceholderController.ts
@@ -40,40 +40,37 @@ contract("PlaceholderController", function([_, investor, wallet, recipient]) {
     await advanceBlock();
   });
 
-  it(
-    "allows transfers when the placeholder is the controller",
-    async function() {
-      const latestTime = latestBlockTime();
+  it("allows transfers when the placeholder is the controller", async function() {
+    const latestTime = latestBlockTime();
 
-      const sale = await BloomTokenSale.new(
-        latestTime + 5,
-        latestTime + 20,
-        new BigNumber(1000),
-        wallet,
-        web3.eth.getBalance(wallet).add(1000)
-      );
+    const sale = await BloomTokenSale.new(
+      latestTime + 5,
+      latestTime + 20,
+      new BigNumber(1000),
+      wallet,
+      web3.eth.getBalance(wallet).add(1000)
+    );
 
-      const token = await BLT.new();
-      const placeholder = await PlaceholderController.new(token.address);
-      await token.changeController(sale.address);
-      await sale.setToken(token.address);
-      await sale.allocateSupply();
-      await sale.finishConfiguration();
+    const token = await BLT.new();
+    const placeholder = await PlaceholderController.new(token.address);
+    await token.changeController(sale.address);
+    await sale.setToken(token.address);
+    await sale.allocateSupply();
+    await sale.finishPresale(40000);
 
-      await timer(5);
+    await timer(5);
 
-      await sale.sendTransaction({ value: 1000, from: investor });
-      await token
-        .transfer(recipient, 500, { from: investor })
-        .should.be.rejectedWith("invalid opcode");
+    await sale.sendTransaction({ value: 1000, from: investor });
+    await token
+      .transfer(recipient, 500, { from: investor })
+      .should.be.rejectedWith("invalid opcode");
 
-      await timer(25);
+    await timer(25);
 
-      await sale.finalize();
-      await sale.changeTokenController(placeholder.address);
-      await token.transfer(recipient, 500, {
-        from: investor
-      }).should.be.fulfilled;
-    }
-  );
+    await sale.finalize();
+    await sale.changeTokenController(placeholder.address);
+    await token.transfer(recipient, 500, {
+      from: investor
+    }).should.be.fulfilled;
+  });
 });


### PR DESCRIPTION
 - Move the previous logic which lived in `finishConfiguration` over
   to the more descriptive `finishPresale`

 - The `finishPresale` method sets the price and the existing function
   for setting the ether price is moved to an internal function

 - Tests are tweaked accordingly. I deleted one test which was hard
   to assert now that I can't set a fake cap of 1000 wei. The test isn't
   really necessary anyways since it is strictly testing Crowdsale.sol
   behavior which is from the zeppelin suite

Fixes #89