### PR TITLE
Add presale token support for adjustment controller

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,4 @@ test:
   override:
     - bin/compile-typings && git diff --exit-code
     - bin/test
-    - git ls-files contracts | grep -v 'MiniMeToken.sol' | xargs bin/lint
+    - git ls-files contracts | egrep -v '(MiniMeToken|TokenVesting).sol' | xargs bin/lint

--- a/contracts.d.ts
+++ b/contracts.d.ts
@@ -51,6 +51,16 @@ export interface ApproveAndCallFallBackContract {
 
 export interface BloomPriceAdjustmentControllerInstance
   extends ContractInstance {
+  grantSixMonthLockupTokens: {
+    (recipient: Address, amount: UInt, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      recipient: Address,
+      amount: UInt,
+      options?: TransactionOptions
+    ): Promise<Address>;
+  };
   PERCENT_INCREASE: {
     (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
     call(options?: TransactionOptions): Promise<BigNumber.BigNumber>;
@@ -63,6 +73,20 @@ export interface BloomPriceAdjustmentControllerInstance
       buyer: Address,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>;
+  };
+  grantNoLockupPresaleTokens: {
+    (recipient: Address, amount: UInt, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      recipient: Address,
+      amount: UInt,
+      options?: TransactionOptions
+    ): Promise<Address>;
+  };
+  SALE_START_TIME: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
+    call(options?: TransactionOptions): Promise<BigNumber.BigNumber>;
   };
   onTransfer: {
     (
@@ -101,6 +125,32 @@ export interface BloomPriceAdjustmentControllerInstance
     (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
     call(options?: TransactionOptions): Promise<Address>;
   };
+  vestingVehicles: {
+    (unnamed2: UInt, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(unnamed2: UInt, options?: TransactionOptions): Promise<Address>;
+  };
+  grantThreeMonthLockupTokens: {
+    (recipient: Address, amount: UInt, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      recipient: Address,
+      amount: UInt,
+      options?: TransactionOptions
+    ): Promise<Address>;
+  };
+  grantOneYearLockupTokens: {
+    (recipient: Address, amount: UInt, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      recipient: Address,
+      amount: UInt,
+      options?: TransactionOptions
+    ): Promise<Address>;
+  };
   changeTokenController: {
     (newController: Address, options?: TransactionOptions): Promise<
       Web3.TransactionReceipt
@@ -112,15 +162,15 @@ export interface BloomPriceAdjustmentControllerInstance
   };
   onApprove: {
     (
-      unnamed2: Address,
       unnamed3: Address,
-      unnamed4: UInt,
+      unnamed4: Address,
+      unnamed5: UInt,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>;
     call(
-      unnamed2: Address,
       unnamed3: Address,
-      unnamed4: UInt,
+      unnamed4: Address,
+      unnamed5: UInt,
       options?: TransactionOptions
     ): Promise<boolean>;
   };
@@ -134,10 +184,10 @@ export interface BloomPriceAdjustmentControllerInstance
     ): Promise<Web3.TransactionReceipt>;
   };
   proxyPayment: {
-    (unnamed5: Address, options?: TransactionOptions): Promise<
+    (unnamed6: Address, options?: TransactionOptions): Promise<
       Web3.TransactionReceipt
     >;
-    call(unnamed5: Address, options?: TransactionOptions): Promise<boolean>;
+    call(unnamed6: Address, options?: TransactionOptions): Promise<boolean>;
   };
   token: {
     (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
@@ -202,13 +252,13 @@ export interface BloomTokenSaleInstance extends ContractInstance {
     (
       from: Address,
       to: Address,
-      unnamed6: UInt,
+      unnamed7: UInt,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>;
     call(
       from: Address,
       to: Address,
-      unnamed6: UInt,
+      unnamed7: UInt,
       options?: TransactionOptions
     ): Promise<boolean>;
   };
@@ -279,15 +329,15 @@ export interface BloomTokenSaleInstance extends ContractInstance {
   };
   onApprove: {
     (
-      unnamed7: Address,
       unnamed8: Address,
-      unnamed9: UInt,
+      unnamed9: Address,
+      unnamed10: UInt,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>;
     call(
-      unnamed7: Address,
       unnamed8: Address,
-      unnamed9: UInt,
+      unnamed9: Address,
+      unnamed10: UInt,
       options?: TransactionOptions
     ): Promise<boolean>;
   };
@@ -402,10 +452,10 @@ export interface BLTInstance extends ContractInstance {
     call(options?: TransactionOptions): Promise<BigNumber.BigNumber>;
   };
   canCreateGrants: {
-    (unnamed10: Address, options?: TransactionOptions): Promise<
+    (unnamed11: Address, options?: TransactionOptions): Promise<
       Web3.TransactionReceipt
     >;
-    call(unnamed10: Address, options?: TransactionOptions): Promise<boolean>;
+    call(unnamed11: Address, options?: TransactionOptions): Promise<boolean>;
   };
   setCanCreateGrants: {
     (addr: Address, allowed: boolean, options?: TransactionOptions): Promise<
@@ -433,13 +483,13 @@ export interface BLTInstance extends ContractInstance {
   };
   grants: {
     (
-      unnamed11: Address,
-      unnamed12: UInt,
+      unnamed12: Address,
+      unnamed13: UInt,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>;
     call(
-      unnamed11: Address,
-      unnamed12: UInt,
+      unnamed12: Address,
+      unnamed13: UInt,
       options?: TransactionOptions
     ): Promise<
       [
@@ -848,6 +898,104 @@ export interface CrowdsaleContract {
   at(address: string): CrowdsaleInstance;
 }
 
+export interface ERC20Instance extends ContractInstance {
+  approve: {
+    (spender: Address, value: UInt, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      spender: Address,
+      value: UInt,
+      options?: TransactionOptions
+    ): Promise<boolean>;
+  };
+  totalSupply: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
+    call(options?: TransactionOptions): Promise<BigNumber.BigNumber>;
+  };
+  transferFrom: {
+    (
+      from: Address,
+      to: Address,
+      value: UInt,
+      options?: TransactionOptions
+    ): Promise<Web3.TransactionReceipt>;
+    call(
+      from: Address,
+      to: Address,
+      value: UInt,
+      options?: TransactionOptions
+    ): Promise<boolean>;
+  };
+  balanceOf: {
+    (who: Address, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      who: Address,
+      options?: TransactionOptions
+    ): Promise<BigNumber.BigNumber>;
+  };
+  transfer: {
+    (to: Address, value: UInt, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      to: Address,
+      value: UInt,
+      options?: TransactionOptions
+    ): Promise<boolean>;
+  };
+  allowance: {
+    (owner: Address, spender: Address, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      owner: Address,
+      spender: Address,
+      options?: TransactionOptions
+    ): Promise<BigNumber.BigNumber>;
+  };
+}
+
+export interface ERC20Contract {
+  new: () => Promise<ERC20Instance>;
+  deployed(): Promise<ERC20Instance>;
+  at(address: string): ERC20Instance;
+}
+
+export interface ERC20BasicInstance extends ContractInstance {
+  totalSupply: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
+    call(options?: TransactionOptions): Promise<BigNumber.BigNumber>;
+  };
+  balanceOf: {
+    (who: Address, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      who: Address,
+      options?: TransactionOptions
+    ): Promise<BigNumber.BigNumber>;
+  };
+  transfer: {
+    (to: Address, value: UInt, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      to: Address,
+      value: UInt,
+      options?: TransactionOptions
+    ): Promise<boolean>;
+  };
+}
+
+export interface ERC20BasicContract {
+  new: () => Promise<ERC20BasicInstance>;
+  deployed(): Promise<ERC20BasicInstance>;
+  at(address: string): ERC20BasicInstance;
+}
+
 export interface FinalizableCrowdsaleInstance extends ContractInstance {
   rate: {
     (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
@@ -1234,10 +1382,10 @@ export interface MiniMeVestedTokenInstance extends ContractInstance {
     call(options?: TransactionOptions): Promise<BigNumber.BigNumber>;
   };
   canCreateGrants: {
-    (unnamed13: Address, options?: TransactionOptions): Promise<
+    (unnamed14: Address, options?: TransactionOptions): Promise<
       Web3.TransactionReceipt
     >;
-    call(unnamed13: Address, options?: TransactionOptions): Promise<boolean>;
+    call(unnamed14: Address, options?: TransactionOptions): Promise<boolean>;
   };
   setCanCreateGrants: {
     (addr: Address, allowed: boolean, options?: TransactionOptions): Promise<
@@ -1265,13 +1413,13 @@ export interface MiniMeVestedTokenInstance extends ContractInstance {
   };
   grants: {
     (
-      unnamed14: Address,
-      unnamed15: UInt,
+      unnamed15: Address,
+      unnamed16: UInt,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>;
     call(
-      unnamed14: Address,
-      unnamed15: UInt,
+      unnamed15: Address,
+      unnamed16: UInt,
       options?: TransactionOptions
     ): Promise<
       [
@@ -1608,15 +1756,15 @@ export interface PausableContract {
 export interface PlaceholderControllerInstance extends ContractInstance {
   onTransfer: {
     (
-      unnamed16: Address,
       unnamed17: Address,
-      unnamed18: UInt,
+      unnamed18: Address,
+      unnamed19: UInt,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>;
     call(
-      unnamed16: Address,
       unnamed17: Address,
-      unnamed18: UInt,
+      unnamed18: Address,
+      unnamed19: UInt,
       options?: TransactionOptions
     ): Promise<boolean>;
   };
@@ -1635,15 +1783,15 @@ export interface PlaceholderControllerInstance extends ContractInstance {
   };
   onApprove: {
     (
-      unnamed19: Address,
       unnamed20: Address,
-      unnamed21: UInt,
+      unnamed21: Address,
+      unnamed22: UInt,
       options?: TransactionOptions
     ): Promise<Web3.TransactionReceipt>;
     call(
-      unnamed19: Address,
       unnamed20: Address,
-      unnamed21: UInt,
+      unnamed21: Address,
+      unnamed22: UInt,
       options?: TransactionOptions
     ): Promise<boolean>;
   };
@@ -1657,10 +1805,10 @@ export interface PlaceholderControllerInstance extends ContractInstance {
     ): Promise<Web3.TransactionReceipt>;
   };
   proxyPayment: {
-    (unnamed22: Address, options?: TransactionOptions): Promise<
+    (unnamed23: Address, options?: TransactionOptions): Promise<
       Web3.TransactionReceipt
     >;
-    call(unnamed22: Address, options?: TransactionOptions): Promise<boolean>;
+    call(unnamed23: Address, options?: TransactionOptions): Promise<boolean>;
   };
   token: {
     (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
@@ -1672,6 +1820,14 @@ export interface PlaceholderControllerContract {
   new: (blt: Address) => Promise<PlaceholderControllerInstance>;
   deployed(): Promise<PlaceholderControllerInstance>;
   at(address: string): PlaceholderControllerInstance;
+}
+
+export interface SafeERC20Instance extends ContractInstance {}
+
+export interface SafeERC20Contract {
+  new: () => Promise<SafeERC20Instance>;
+  deployed(): Promise<SafeERC20Instance>;
+  at(address: string): SafeERC20Instance;
 }
 
 export interface SafeMathInstance extends ContractInstance {}
@@ -1723,4 +1879,103 @@ export interface TokenControllerContract {
   new: () => Promise<TokenControllerInstance>;
   deployed(): Promise<TokenControllerInstance>;
   at(address: string): TokenControllerInstance;
+}
+
+export interface TokenVestingInstance extends ContractInstance {
+  duration: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
+    call(options?: TransactionOptions): Promise<BigNumber.BigNumber>;
+  };
+  cliff: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
+    call(options?: TransactionOptions): Promise<BigNumber.BigNumber>;
+  };
+  releasableAmount: {
+    (token: Address, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      token: Address,
+      options?: TransactionOptions
+    ): Promise<BigNumber.BigNumber>;
+  };
+  release: {
+    (token: Address, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      token: Address,
+      options?: TransactionOptions
+    ): Promise<Web3.TransactionReceipt>;
+  };
+  vestedAmount: {
+    (token: Address, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      token: Address,
+      options?: TransactionOptions
+    ): Promise<BigNumber.BigNumber>;
+  };
+  beneficiary: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
+    call(options?: TransactionOptions): Promise<Address>;
+  };
+  revoke: {
+    (token: Address, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      token: Address,
+      options?: TransactionOptions
+    ): Promise<Web3.TransactionReceipt>;
+  };
+  revocable: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
+    call(options?: TransactionOptions): Promise<boolean>;
+  };
+  owner: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
+    call(options?: TransactionOptions): Promise<Address>;
+  };
+  released: {
+    (unnamed24: Address, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      unnamed24: Address,
+      options?: TransactionOptions
+    ): Promise<BigNumber.BigNumber>;
+  };
+  start: {
+    (options?: TransactionOptions): Promise<Web3.TransactionReceipt>;
+    call(options?: TransactionOptions): Promise<BigNumber.BigNumber>;
+  };
+  transferOwnership: {
+    (newOwner: Address, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(
+      newOwner: Address,
+      options?: TransactionOptions
+    ): Promise<Web3.TransactionReceipt>;
+  };
+  revoked: {
+    (unnamed25: Address, options?: TransactionOptions): Promise<
+      Web3.TransactionReceipt
+    >;
+    call(unnamed25: Address, options?: TransactionOptions): Promise<boolean>;
+  };
+}
+
+export interface TokenVestingContract {
+  new: (
+    beneficiary: Address,
+    start: UInt,
+    cliff: UInt,
+    duration: UInt,
+    revocable: boolean
+  ) => Promise<TokenVestingInstance>;
+  deployed(): Promise<TokenVestingInstance>;
+  at(address: string): TokenVestingInstance;
 }

--- a/contracts/TokenVesting.sol
+++ b/contracts/TokenVesting.sol
@@ -1,0 +1,114 @@
+pragma solidity 0.4.15;
+
+import 'zeppelin/token/ERC20Basic.sol';
+import 'zeppelin/token/SafeERC20.sol';
+import 'zeppelin/ownership/Ownable.sol';
+import 'zeppelin/math/SafeMath.sol';
+
+/**
+ * @title TokenVesting
+ * @dev A token holder contract that can release its token balance gradually like a
+ * typical vesting scheme, with a cliff and vesting period. Optionally revocable by the
+ * owner.
+ */
+contract TokenVesting is Ownable {
+  using SafeMath for uint256;
+  using SafeERC20 for ERC20Basic;
+
+  event Released(uint256 amount);
+  event Revoked();
+
+  // beneficiary of tokens after they are released
+  address public beneficiary;
+
+  uint256 public cliff;
+  uint256 public start;
+  uint256 public duration;
+
+  bool public revocable;
+
+  mapping (address => uint256) public released;
+  mapping (address => bool) public revoked;
+
+  /**
+   * @dev Creates a vesting contract that vests its balance of any ERC20 token to the
+   * _beneficiary, gradually in a linear fashion until _start + _duration. By then all
+   * of the balance will have vested.
+   * @param _beneficiary address of the beneficiary to whom vested tokens are transferred
+   * @param _cliff duration in seconds of the cliff in which tokens will begin to vest
+   * @param _duration duration in seconds of the period in which the tokens will vest
+   * @param _revocable whether the vesting is revocable or not
+   */
+  function TokenVesting(address _beneficiary, uint256 _start, uint256 _cliff, uint256 _duration, bool _revocable) public {
+    require(_beneficiary != address(0));
+    require(_cliff <= _duration);
+
+    beneficiary = _beneficiary;
+    revocable = _revocable;
+    duration = _duration;
+    cliff = _start.add(_cliff);
+    start = _start;
+  }
+
+  /**
+   * @notice Transfers vested tokens to beneficiary.
+   * @param token ERC20 token which is being vested
+   */
+  function release(ERC20Basic token) public {
+    uint256 unreleased = releasableAmount(token);
+
+    require(unreleased > 0);
+
+    released[token] = released[token].add(unreleased);
+
+    token.safeTransfer(beneficiary, unreleased);
+
+    Released(unreleased);
+  }
+
+  /**
+   * @notice Allows the owner to revoke the vesting. Tokens already vested
+   * remain in the contract, the rest are returned to the owner.
+   * @param token ERC20 token which is being vested
+   */
+  function revoke(ERC20Basic token) public onlyOwner {
+    require(revocable);
+    require(!revoked[token]);
+
+    uint256 balance = token.balanceOf(this);
+
+    uint256 unreleased = releasableAmount(token);
+    uint256 refund = balance.sub(unreleased);
+
+    revoked[token] = true;
+
+    token.safeTransfer(owner, refund);
+
+    Revoked();
+  }
+
+  /**
+   * @dev Calculates the amount that has already vested but hasn't been released yet.
+   * @param token ERC20 token which is being vested
+   */
+  function releasableAmount(ERC20Basic token) public constant returns (uint256) {
+    return vestedAmount(token).sub(released[token]);
+  }
+
+  /**
+   * @dev Calculates the amount that has already vested.
+   * @param token ERC20 token which is being vested
+   */
+  function vestedAmount(ERC20Basic token) public constant returns (uint256) {
+    uint256 currentBalance = token.balanceOf(this);
+    uint256 totalBalance = currentBalance.add(released[token]);
+
+    if (now < cliff) {
+      return 0;
+    } else if (now >= start.add(duration) || revoked[token]) {
+      return totalBalance;
+    } else {
+      return totalBalance.mul(now.sub(start)).div(duration);
+    }
+  }
+}

--- a/truffle.d.ts
+++ b/truffle.d.ts
@@ -5,7 +5,9 @@ import {
   MiniMeTokenInstance,
   MiniMeVestedTokenInstance,
   PlaceholderControllerInstance,
-  BloomPriceAdjustmentControllerInstance
+  BloomPriceAdjustmentControllerInstance,
+  TokenVestingInstance,
+  TokenVestingContract
 } from "./contracts";
 
 declare global {
@@ -108,4 +110,5 @@ interface Artifacts {
   require(name: "./helpers/MockSale"): Contract<MockSaleInstance>;
   require(name: "./helpers/MockToken"): Contract<MockTokenInstance>;
   require(name: "./helpers/MockBLT"): Contract<MockBLTInstance>;
+  require(name: "TokenVesting"): TokenVestingContract;
 }


### PR DESCRIPTION
We need to reissue presale and advisor tokens too. This provides
an external vehicle for vesting these tokens as well as simple
interfaces for creating the vested tokens.